### PR TITLE
Modify port parsing

### DIFF
--- a/cmd/explode_test.go
+++ b/cmd/explode_test.go
@@ -1,0 +1,43 @@
+package main
+
+import "testing"
+
+const (
+	dashRange    = "1-20"
+	singlePort   = "4444"
+	dashAndComma = "1,2,3,4,5-10"
+)
+
+func TestDashSplit(t *testing.T) {
+	ports := []int{}
+	err := dashSplit(dashRange, &ports)
+	if err != nil {
+		t.Error(err)
+	}
+	expected := 20
+	if len(ports) != expected {
+		t.Errorf("Expected length of %d and got %d\n", expected, len(ports))
+	}
+}
+
+func TestConvertAndAddPort(t *testing.T) {
+	ports := []int{}
+	err := convertAndAddPort(singlePort, &ports)
+	if err != nil {
+		t.Error(err)
+	}
+	if ports[0] != 4444 {
+		t.Error("Expected 4444 and got", ports[0])
+	}
+}
+
+func TestExplode(t *testing.T) {
+	ports, err := explode(dashAndComma)
+	if err != nil {
+		t.Error(err)
+	}
+	expected := 10
+	if len(ports) != expected {
+		t.Errorf("Expexted length of %d and got %d\n", expected, len(ports))
+	}
+}

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -48,7 +48,7 @@ type O struct {
 }
 
 func parse() *O {
-	args, err := docopt.Parse(usage, nil, true, "cookiescan 2.1.0", false)
+	args, err := docopt.Parse(usage, nil, true, "cookiescan 2.2.0", false)
 	if err != nil {
 		log.Fatalf("Error parsing usage. Error: %s\n", err.Error())
 	}


### PR DESCRIPTION
Before you had to either split ports by comma or dash ie 1,2,3 or 1-3.

Now you can combine the two methods ie 1,2,3-10