### PR TITLE
Add the ability to parse dashed networks

### DIFF
--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/docopt/docopt-go"
@@ -48,7 +49,7 @@ type O struct {
 }
 
 func parse() *O {
-	args, err := docopt.Parse(usage, nil, true, "cookiescan 2.2.0", false)
+	args, err := docopt.Parse(usage, nil, true, "cookiescan 2.3.0", false)
 	if err != nil {
 		log.Fatalf("Error parsing usage. Error: %s\n", err.Error())
 	}
@@ -123,7 +124,7 @@ func parse() *O {
 	return o
 }
 
-// linesToIPList processes a list of IP addresses or networks in CIDR format.
+// linesToIPList processes a list of IP addresses or networks in CIDR or dash format.
 // Returning a list of all possible IP addresses.
 func linesToIPList(lines []string) ([]string, error) {
 	ipList := []string{}
@@ -133,6 +134,27 @@ func linesToIPList(lines []string) ([]string, error) {
 		} else if ip, network, err := net.ParseCIDR(line); err == nil {
 			for ip := ip.Mask(network.Mask); network.Contains(ip); increaseIP(ip) {
 				ipList = append(ipList, ip.String())
+			}
+		} else if strings.Contains(line, "-") {
+			splitIP := strings.SplitN(line, "-", 2)
+			ip := net.ParseIP(splitIP[0])
+			endIP := net.ParseIP(splitIP[1])
+			if endIP != nil {
+				ipList = append(ipList, ip.String())
+				for !ip.Equal(endIP) {
+					increaseIP(ip)
+					ipList = append(ipList, ip.String())
+				}
+			} else {
+				ipOct := strings.SplitN(ip.String(), ".", 4)
+				endIP := net.ParseIP(ipOct[0] + "." + ipOct[1] + "." + ipOct[2] + "." + splitIP[1])
+				if endIP != nil {
+					ipList = append(ipList, ip.String())
+					for !ip.Equal(endIP) {
+						increaseIP(ip)
+						ipList = append(ipList, ip.String())
+					}
+				}
 			}
 		} else {
 			return ipList, fmt.Errorf("%s is not an IP Address or CIDR Network", line)

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -156,13 +156,10 @@ func linesToIPList(lines []string) ([]string, error) {
 					}
 				}
 			}
+		} else if ip, err := net.LookupIP(line); err == nil {
+			ipList = append(ipList, ip[0].String())
 		} else {
 			return ipList, fmt.Errorf("%s is not an IP Address or CIDR Network", line)
-			ips, err := net.LookupIP(line)
-			if err != nil {
-				return ipList, fmt.Errorf("%s is not a valid hostname", line)
-			}
-			ipList = append(ipList, ips[0].String())
 		}
 	}
 	return ipList, nil


### PR DESCRIPTION
Network example 192.168.1.1-10 is expanded to 192.168.1.1-192.168.1.10
and then those IPs are added to the ipList array.

Network example 192.168.1.1-192.168.1.10 is looped over and added to the
ipList array.